### PR TITLE
feat: auth decorator

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": ["ESNext"],
     "module": "esnext",
     "target": "esnext",
+    "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "moduleDetection": "force",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
This is adding `@authenticated` property decorator to enforce `authStatus==VALID` before calling tapper-sdk protected endpoints. 

It fails fast if the `accessToken` is not valid, otherwise the `sdk` would make the request and then fail due to lack of authentication.