### PR TITLE
fix: minimize user data exposed

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -58,7 +58,9 @@ describe("Supertab", () => {
             res(ctx.status(200), ctx.json(UserResponseToJSON(user))),
         ),
       );
-      expect(await client.getCurrentUser()).toEqual(user);
+      expect(await client.getCurrentUser()).toEqual({
+        id: user.id,
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,13 @@ export class Supertab {
 
   @authenticated
   async getCurrentUser() {
-    return new UserIdentityApi(this.tapperConfig).getCurrentUserV1();
+    const user = await new UserIdentityApi(
+      this.tapperConfig,
+    ).getCurrentUserV1();
+
+    return {
+      id: user.id,
+    };
   }
+
 }


### PR DESCRIPTION
Expose only `.id` of current user and add new fields later as needed to avoid exposing unnecessary data