### PR TITLE
fix: remove duplicate `localeCode` property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,6 @@ export class Supertab {
         currency: currency.isoCode,
         baseUnit: currency.baseUnit,
         localeCode: language,
-        localeCode: this.language,
         showZeroFractionDigits: true,
       });
 


### PR DESCRIPTION
This PR removes the duplicate `localeCode` property in `index.ts`'s `getOfferings()` function.