### PR TITLE
fix: Correct semver syntax error in peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lint:fix": "eslint --fix --ext .ts ."
   },
   "peerDependencies": {
-    "typescript": "^4.0.0 | ^5.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@laterpay/auth": "^1.1.3",


### PR DESCRIPTION
The semver range is missing a second pipe.
