### PR TITLE
feat: make `silently` optional in `auth` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export class Supertab {
     },
   ) {
     return authFlow({
-      silently: silently ?? false,
+      silently: !!silently,
       screenHint,
       state,
       authBaseUrl: AUTH_BASE_URL,


### PR DESCRIPTION
This PR makes `silently` optional in `auth` function.