### PR TITLE
feat: pass `usd` for currency param in config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -12,9 +12,8 @@
     [
       "@semantic-release/git",
       {
-        message:
-          "chore: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-      },
+        "message": "chore: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
     ]
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ export class Supertab {
       this.tapperConfig,
     ).getClientConfigV1({
       clientId: this.clientId,
+      currency: "USD",
     });
 
     return this._clientConfig;


### PR DESCRIPTION
This PR adds `USD` currency param when fetching client config as a workaround for when `single_purchase` offering is created with no other prices than USD. It unblocks `supertab-js` project.

Ref: https://laterpay.atlassian.net/browse/CL-1237