### PR TITLE
feat: return `salesModel` for offerings

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -116,6 +116,7 @@ describe("Supertab", () => {
           {
             id: "test-offering-id",
             description: "Test Offering Description",
+            salesModel: "time_pass",
             price: {
               amount: 100,
               currency: "USD",
@@ -160,6 +161,7 @@ describe("Supertab", () => {
           {
             id: "test-offering-id",
             description: "Test Offering Description",
+            salesModel: "time_pass",
             price: {
               amount: 100,
               currency: "BRL",
@@ -183,6 +185,7 @@ describe("Supertab", () => {
         {
           id: "test-offering-id",
           description: "Test Offering Description",
+          salesModel: "time_pass",
           price: "R$ 1,00",
         },
       ]);

--- a/__snapshots__/Supertab.test.ts.snap
+++ b/__snapshots__/Supertab.test.ts.snap
@@ -18,6 +18,7 @@ exports[`Supertab .getOfferings return offerings with default currency 1`] = `
         "text": "€1.00",
       },
     ],
+    "salesModel": "time_pass",
   },
 ]
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ export class Supertab {
         return {
           id: eachOffering.id,
           description: eachOffering.description,
+          salesModel: eachOffering.salesModel,
           price: getPrice(eachOffering, eachOffering.price).text,
           prices,
         };


### PR DESCRIPTION
This PR adds `salesModel` to the returned offerings in `getOfferings()` function.