### PR TITLE
feat: preload popup url using fetch

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -15,9 +15,9 @@ export const handleChildWindow = async <T>({
     throw new Error("Window is null");
   }
 
-  setTimeout(() => {
-    openedWindow.location.href = url.toString();
-  }, 3000);
+  fetch(url.toString()).then(
+    () => (openedWindow.location.href = url.toString()),
+  );
 
   let receivedPostMessage = false;
 


### PR DESCRIPTION
This PR adds preloading of a popup URL using fetch and removes 3s timeout while playing
the animation. With this, loading animation serves its purpose and is only shown for a time
needed to load the target URL.

Ref: https://laterpay.atlassian.net/browse/CL-1279