### PR TITLE
fix: add viewport tag to opened windows to fix scaling

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -15,10 +15,9 @@ export const handleChildWindow = async <T>({
     throw new Error("Window is null");
   }
 
-  fetch(url.toString())
-    .then
-      () => (openedWindow.location.href = url.toString())
-    ();
+  fetch(url.toString()).then(
+    () => (openedWindow.location.href = url.toString()),
+  );
 
   let receivedPostMessage = false;
 


### PR DESCRIPTION
This PR adds `viewport` meta tag to fix scaling of the loading animation on mobile devices.