### PR TITLE
feat: new function names

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -82,7 +82,7 @@ describe("Supertab", () => {
     });
   });
 
-  describe(".getCurrentUser", () => {
+  describe(".getUser", () => {
     test("return logged user from tapper", async () => {
       const { client } = setup();
 
@@ -99,7 +99,7 @@ describe("Supertab", () => {
 
       server.withCurrentUser(user);
 
-      expect(await client.getCurrentUser()).toEqual({ id: user.id });
+      expect(await client.getUser()).toEqual({ id: user.id });
     });
   });
 
@@ -242,7 +242,7 @@ describe("Supertab", () => {
     });
   });
 
-  describe(".getUserTab", () => {
+  describe(".getTab", () => {
     test.each([TabStatus.Open, TabStatus.Full])(
       "return user's %s tab",
       async (status) => {
@@ -312,7 +312,7 @@ describe("Supertab", () => {
           },
         });
 
-        expect(await client.getUserTab()).toEqual({
+        expect(await client.getTab()).toEqual({
           id: "test-tab-id",
           status,
           total: 50,
@@ -348,7 +348,7 @@ describe("Supertab", () => {
         },
       });
 
-      expect(await client.getUserTab()).toBeUndefined();
+      expect(await client.getTab()).toBeUndefined();
     });
 
     test("return undefined if no open tab", async () => {
@@ -418,11 +418,11 @@ describe("Supertab", () => {
         },
       });
 
-      expect(await client.getUserTab()).toBeUndefined();
+      expect(await client.getTab()).toBeUndefined();
     });
   });
 
-  describe(".pay", () => {
+  describe(".payTab", () => {
     beforeEach(() => {
       server.withGetTabById({
         id: "test-tab-id",
@@ -444,7 +444,7 @@ describe("Supertab", () => {
 
     test("opens checkout popup", async () => {
       const { client, windowOpen, emitter, checkoutWindow } = setup();
-      const payment = client.pay("test-tab-id");
+      const payment = client.payTab("test-tab-id");
 
       //wait a tick to interact with the window
       await nextTick();
@@ -471,7 +471,7 @@ describe("Supertab", () => {
 
     test("return success if checkout page succeeds", async () => {
       const { client, checkoutWindow, emitter } = setup();
-      const payment = client.pay("test-tab-id");
+      const payment = client.payTab("test-tab-id");
 
       //wait a tick to interact with the window
       await nextTick();
@@ -489,7 +489,7 @@ describe("Supertab", () => {
 
     test("throw an error if not authenticated", () => {
       const { client } = setup({ authenticated: false });
-      expect(async () => await client.pay("test-tab-id")).toThrow(
+      expect(async () => await client.payTab("test-tab-id")).toThrow(
         /Missing auth/,
       );
     });
@@ -498,7 +498,7 @@ describe("Supertab", () => {
       const { client, checkoutWindow, emitter } = setup();
 
       expect(async () => {
-        const payment = client.pay("test-tab-id");
+        const payment = client.payTab("test-tab-id");
 
         //wait a tick to interact with the window
         await nextTick();
@@ -520,7 +520,7 @@ describe("Supertab", () => {
       checkoutWindow.closed = true;
 
       const payment = new Promise((resolve) => {
-        return client.pay("test-tab-id").then(resolve);
+        return client.payTab("test-tab-id").then(resolve);
       });
 
       payment.then((res) => {
@@ -549,7 +549,7 @@ describe("Supertab", () => {
       });
 
       expect(async () => {
-        const payment = client.pay("test-tab-id");
+        const payment = client.payTab("test-tab-id");
 
         await payment;
       }).toThrow(/Tab is not full/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export class Supertab {
     return getAuthStatus();
   }
 
-  async auth({
+  async authorize({
     silently,
     screenHint,
     state,
@@ -99,7 +99,7 @@ export class Supertab {
   }
 
   @authenticated
-  async getCurrentUser() {
+  async getUser() {
     const user = await new UserIdentityApi(
       this.tapperConfig,
     ).getCurrentUserV1();
@@ -195,7 +195,7 @@ export class Supertab {
   }
 
   @authenticated
-  async getUserTab() {
+  async getTab() {
     const {
       data: [tab],
     } = await new TabsApi(this.tapperConfig).paginatedTabsListUserV1({
@@ -224,7 +224,7 @@ export class Supertab {
   }
 
   @authenticated
-  async pay(id: string) {
+  async payTab(id: string) {
     const checkoutWindow = openBlankChildWindow({
       width: 400,
       height: 800,
@@ -267,7 +267,7 @@ export class Supertab {
     offeringId: string;
     preferredCurrency: string;
   }) {
-    const tab = await this.getUserTab();
+    const tab = await this.getTab();
     const currency = tab?.currency || preferredCurrency;
 
     try {
@@ -312,7 +312,7 @@ export class Supertab {
     }
   }
 
-  async openPersonalMarketingPage() {
+  async openAboutSupertab() {
     const url = new URL("https://supertab.co/personal");
     window.open(url, "_blank");
   }


### PR DESCRIPTION
This PR updates function names based on the feedback from the product team. Tests were also updated to reflect these changes.

BREAKING CHANGE:
* `auth` is now `authorize`.
* `getCurrentUser` is now `getUser`.
* `getUserTab` is now `getTab`.
* `pay` is now `payTab`.
* `openPersonalMarketingPage` is now `openAboutSupertab`.