### PR TITLE
fix: safer dom manipulation for loading animation

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -64,20 +64,26 @@ export const openBlankChildWindow = ({
   }
 
   const newWindow = window.open("", target ?? "_blank", windowFeatures);
+  let newWindowDocument = null;
 
-  if (newWindow) {
-    const newWindowDoc = newWindow.document;
+  try {
+    newWindowDocument = newWindow?.document;
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
 
-    if (newWindowDoc) {
-      newWindowDoc.write(
-        '<html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"><title>Supertab</title></head>',
-      );
-      newWindowDoc.write(
-        `<body style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%" >
-        <img style="width: 180px; height: auto" src="${omegaAnimation}" />
-        <p style="margin-top: -10px; font-size: 16px; font-weight: 400; color: #555; font-family: Helvetica">Loading your Supertab...</p></body></html>`,
-      );
-    }
+  if (
+    newWindowDocument &&
+    newWindowDocument.getElementById("supertab-loading-animation") === null
+  ) {
+    newWindowDocument.write(
+      '<html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"><title>Supertab</title></head>',
+    );
+    newWindowDocument.write(
+      `<body style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%" id="supertab-loading-animation">
+          <img style="width: 180px; height: auto" src="${omegaAnimation}" />
+          <p style="margin-top: -10px; font-size: 16px; font-weight: 400; color: #555; font-family: Helvetica">Loading your Supertab...</p></body></html>`,
+    );
   }
+
   return newWindow;
 };


### PR DESCRIPTION
This PR adds a safer DOM manipulation for opened popups since `document.write` is not allowed when cross origin. The `document.write` is now only called when the SDK can access the document displayed in a popup.

It also fixes the issue with multiple loading animations appended to DOM when invoking `payTab` or `authorize` functions multiple times while it's still loading and the redirect to the target has not happened yet.

It addresses the unexpected behavior mentioned in https://laterpay.atlassian.net/browse/CL-1280.