### PR TITLE
feat: include formatted price in tab and purchases

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -358,7 +358,10 @@ describe("Supertab", () => {
         expect(await client.getTab()).toEqual({
           id: "test-tab-id",
           status,
-          total: 50,
+          total: {
+            amount: 50,
+            text: "$0.50",
+          },
           limit: 500,
           currency: "USD",
           purchases: [
@@ -368,6 +371,7 @@ describe("Supertab", () => {
               price: {
                 amount: 50,
                 currency: "USD",
+                text: "$0.50",
               },
             },
           ],

--- a/src/price.ts
+++ b/src/price.ts
@@ -4,12 +4,14 @@ export function formatPrice({
   baseUnit,
   localeCode,
   showZeroFractionDigits = false,
+  showSymbol = true,
 }: {
   amount: number;
   currency: string;
   baseUnit: number;
   localeCode: string;
   showZeroFractionDigits?: boolean;
+  showSymbol?: boolean;
 }) {
   const isoCodePattern = new RegExp(currency, "i");
   const amountRest = amount % baseUnit;
@@ -17,17 +19,21 @@ export function formatPrice({
 
   const options = {
     style: "currency",
-    currencyDisplay: "narrowSymbol",
+    currencyDisplay: showSymbol ? "narrowSymbol" : "code",
     currency,
     minimumFractionDigits:
       hasZeroFractionDigits || (showZeroFractionDigits && baseUnit !== 1)
         ? 2
         : 0,
   };
-  const value = new Intl.NumberFormat(localeCode, options)
-    .format(amount / baseUnit)
-    .replace(isoCodePattern, "")
-    .trim();
+  const value = showSymbol
+    ? new Intl.NumberFormat(localeCode, options)
+        .format(amount / baseUnit)
+        .replace(isoCodePattern, "")
+        .trim()
+    : new Intl.NumberFormat(localeCode, options)
+        .format(amount / baseUnit)
+        .trim();
 
   return value;
 }


### PR DESCRIPTION
This PR adds formatted price to the `total` object returned by `getTab()` function and fixes price formatting for currencies without a symbol.

## `getTab` changes

`getTab()` previously returned the following:

```
{
   ...tab
   total: number;
}
```

This PR changes the response exposing both number format of the amount and the formatted amount using the currency of the tab formatted using client browser's locale.

```
{
   ...tab
   total: {
     amount: number;
     text: string;
   }
}
```

**BREAKING CHANGE**: `getTab()` now wraps the total amount on the tab in `total.amount`. `tab.total` becomes object with following keys: `amount` (numeric presentation of the total amount on the tab) and `text` (formatted amount based on the browser locale settings). 

## `formatPrice` changes

This PR also adds `showSymbol` property to the `formatPrice` function which influences `currencyDisplay` property of the `Intl.NumberFormat` options object.

- If `showSymbol` is `false`, it returns the currency code e.g. `USD`. This is useful for currencies without the symbol which is `CHF` (Swiss Franc) among the supported currencies at the time of creating this PR.
- If it's `true`, it returns the symbol e.g. `$`.
     