### PR TITLE
feat: preload URLs for new windows only

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -16,9 +16,13 @@ export const handleChildWindow = async <T>({
   }
 
   try {
-    if (openedWindow.location.href !== url.toString()) {
+    const isUrlOpened = openedWindow.location.href === url.toString();
+    const setWindowLocation = () =>
+      (openedWindow.location.href = url.toString());
+
+    if (!isUrlOpened) {
       fetch(url.toString())
-        .then(() => (openedWindow.location.href = url.toString()))
+        .then(setWindowLocation)
         .catch(() => {});
     }
     // eslint-disable-next-line no-empty


### PR DESCRIPTION
## Problem

As stated in CL-1424, the opened windows (for example a checkout window) was reloaded
when invoking `.payTab()` function again even if the window was still open, instead of refocusing.
This is because we `fetch` the target URL to preload it before changing the `location.href` of the opened window.

## Solution

This PR wraps the aforementioned `fetch` in the try/catch block. If `openedWindow.location.href` does
not equal to the desired window's URL, we proceed with fetch and setting the location.

If it throws, it means we're in a different origin context already (window is loaded) and we no longer
need to prefetch and set the window target manually.

This means the window is refocused (default browser behavior) if it already exists.

### Before

https://github.com/laterpay/supertab-browser/assets/983791/cae3e67b-1fdf-447d-b413-8effce5a3504

### After

https://github.com/laterpay/supertab-browser/assets/983791/221d262e-e86c-4dcc-ba01-744438377913