### PR TITLE
feat: Add flag `isSubscription` to return value of method `checkAccess`

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -428,6 +428,29 @@ describe("Supertab", () => {
       expect(await client.checkAccess()).toEqual({
         access: {
           validTo: new Date(1700119519 * 1000),
+          isSubscription: false,
+        },
+      });
+    });
+
+    test("set flag `isSubscription` for subscription based access", async () => {
+      const { client } = setup();
+
+      server.withClientConfig(accessClientConfig);
+
+      server.withAccessCheck({
+        access: {
+          status: "Granted",
+          contentKey: "test-content-key",
+          validTo: 1700119519,
+          subscriptionId: "test-subscription-id",
+        },
+      });
+
+      expect(await client.checkAccess()).toEqual({
+        access: {
+          validTo: new Date(1700119519 * 1000),
+          isSubscription: true,
         },
       });
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,6 +226,7 @@ export class Supertab {
           validTo: access.access.validTo
             ? new Date(access.access.validTo * 1000)
             : undefined,
+          isSubscription: !!access.access.subscriptionId,
         },
       };
     }


### PR DESCRIPTION
This allows the consuming app to handle time pass based access different from subscription based access (e.g. show individual UI).
