### PR TITLE
feat: Add timepass and subscription details to offerings

### DIFF
--- a/__snapshots__/Supertab.test.ts.snap
+++ b/__snapshots__/Supertab.test.ts.snap
@@ -12,7 +12,9 @@ exports[`Supertab .getOfferings return offerings with default currency 1`] = `
       "text": "$1.00",
     },
     "prices": undefined,
+    "recurringDetails": undefined,
     "salesModel": "time_pass",
+    "timePassDetails": undefined,
   },
 ]
 `;
@@ -29,7 +31,9 @@ exports[`Supertab .getOfferings with no existing tab return offerings with defau
       "text": "$1.00",
     },
     "prices": undefined,
+    "recurringDetails": undefined,
     "salesModel": "time_pass",
+    "timePassDetails": undefined,
   },
 ]
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,8 @@ export class Supertab {
           paymentModel: eachOffering.paymentModel,
           price: getPrice(eachOffering, eachOffering.price, presentedCurrency),
           prices,
+          timePassDetails: eachOffering.timePassDetails,
+          recurringDetails: eachOffering.recurringDetails,
         };
       });
 


### PR DESCRIPTION
This exposes offering details about time pass and subscription validity periods to the consuming app. The use case is for tab.js to be able to show a subscriptions expiry date in the ThankYou state.