### PR TITLE
feat: Normalize tab formatting

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -567,7 +567,7 @@ describe("Supertab", () => {
       },
     );
 
-    test("return undefined if no tabs", async () => {
+    test("return null if no tabs", async () => {
       const { client } = setup();
 
       server.withGetTab({
@@ -583,10 +583,10 @@ describe("Supertab", () => {
         },
       });
 
-      expect(await client.getTab()).toBeUndefined();
+      expect(await client.getTab()).toBeNull();
     });
 
-    test("return undefined if no open tab", async () => {
+    test("return null if no open tab", async () => {
       const { client } = setup();
 
       server.withGetTab({
@@ -653,7 +653,7 @@ describe("Supertab", () => {
         },
       });
 
-      expect(await client.getTab()).toBeUndefined();
+      expect(await client.getTab()).toBeNull();
     });
   });
 
@@ -881,6 +881,19 @@ describe("Supertab", () => {
             amount: 500,
             text: "$5",
           },
+          purchases: [
+            {
+              price: {
+                amount: 50,
+                currency: "USD",
+                text: "$0.50",
+              },
+              purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
+              recurringDetails: undefined,
+              summary: "test-summary",
+              validTo: undefined,
+            },
+          ],
           status: "open",
           total: {
             amount: 50,
@@ -921,6 +934,19 @@ describe("Supertab", () => {
             amount: 500,
             text: "€5",
           },
+          purchases: [
+            {
+              price: {
+                amount: 50,
+                currency: "USD",
+                text: "€0.50",
+              },
+              purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
+              recurringDetails: undefined,
+              summary: "test-summary",
+              validTo: undefined,
+            },
+          ],
           status: "open",
           total: {
             amount: 50,
@@ -960,6 +986,19 @@ describe("Supertab", () => {
               amount: 500,
               text: "R$5",
             },
+            purchases: [
+              {
+                price: {
+                  amount: 50,
+                  currency: "USD",
+                  text: "R$0.50",
+                },
+                purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
+                recurringDetails: undefined,
+                summary: "test-summary",
+                validTo: undefined,
+              },
+            ],
             status: "open",
             total: {
               amount: 50,
@@ -1005,6 +1044,19 @@ describe("Supertab", () => {
             amount: 500,
             text: "$5",
           },
+          purchases: [
+            {
+              price: {
+                amount: 50,
+                currency: "USD",
+                text: "$0.50",
+              },
+              purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
+              recurringDetails: undefined,
+              summary: "test-summary",
+              validTo: undefined,
+            },
+          ],
           status: "full",
           total: {
             amount: 50,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Supertab } from ".";
 import { AuthStatus } from "./auth";
 
 export interface Authenticable {
@@ -12,3 +13,7 @@ export interface SystemUrls {
   tapiBaseUrl: string;
   checkoutBaseUrl: string;
 }
+
+export type FormattedTab = Awaited<
+  ReturnType<typeof Supertab.prototype.formatTab>
+>;

--- a/src/window.ts
+++ b/src/window.ts
@@ -45,7 +45,7 @@ export const handleChildWindow = async <T>({
         clearInterval(checkChildWindowState);
 
         if (!receivedPostMessage) {
-          resolve({ error: "Window closed" } as T);
+          resolve({ status: "error", error: "Window closed" } as T);
         }
       }
     }, 500);


### PR DESCRIPTION
## Goal

1. We want to use normalized tab responses in tab.js, no matter if those come from a purchase, a payment or by fetching an open tab.
2. We need purchase information in the tab summary in order to display subscription validity data to the user in tab.js on the Thank You screen. 

## Problem

- There are three methods that can return a formatted tab
  - getTab
  - purchase
  - payTab
- `getTab` and `purchase` had a lot of repeated inline formatting of the raw Tab response while `payTab` returned the raw tab response in case of payment success.

## Strategy

- Normalize tab formatting
- Always include purchase information with validity and recurring details

## Key changes

- Add new method `formatTab` for DRY-nes and consistency
- Add timepass validity and recurring details to the formatted tab
- Use the new method `formatTab` in responses from `getTab` and `purchase` (mostly a refactoring, the responses stay the same + purchase details)

BREAKING CHANGE: Format the response of`payTab`, too (it was returning the raw TabResponse before)

BREAKING CHANGE: Return `null` instead of `undefined` from `getTab` if no open Tab was found.

- Narrow down response types of the above methods
- Add "status" property to the response of `payTab`. It can be `success` or `error` and makes handling the responses on the consuming end more fun.
