### PR TITLE
fix: Increase checkout window width to fit Stripe subscription form

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ export class Supertab {
     | { status: "error"; error: string }
   > {
     const checkoutWindow = openBlankChildWindow({
-      width: 400,
+      width: 488,
       height: 800,
       target: "supertabCheckout",
     });


### PR DESCRIPTION
Ref: https://laterpay.atlassian.net/browse/CL-1547

## Problem

Stripe's subscription checkout for is wider than the generic checkout form and it overflows the popup window horizontally.

## Solution

Increase the checkout window width to fit Stripe's wider subscription checkout form.

## Measurement

- Form width: 440px
- Padding: 24px * 2 = 48px
- Total width: Form width + padding = 440px + 48px = 488px

<img width="556" alt="Screenshot 2024-07-01 at 16 18 30" src="https://github.com/laterpay/supertab-browser/assets/6692479/8df798e0-4d5c-451a-b870-f7b60c022d63">
<img width="1389" alt="Screenshot 2024-07-01 at 16 18 51" src="https://github.com/laterpay/supertab-browser/assets/6692479/8718f647-d823-4248-add8-44d755e48046">

## Visuals

### Subscription form before

<img width="512" alt="Screenshot 2024-07-01 at 16 40 00" src="https://github.com/laterpay/supertab-browser/assets/6692479/957aa297-6f6f-4372-a67b-831b3b7ec972">

### Subscription form after

<img width="600" alt="Screenshot 2024-07-01 at 16 24 19" src="https://github.com/laterpay/supertab-browser/assets/6692479/7bf9049a-e740-42ec-ba85-cf28ec42934d">

### Generic checkout form after

<img width="600" alt="Screenshot 2024-07-01 at 16 24 00" src="https://github.com/laterpay/supertab-browser/assets/6692479/0644d853-08bb-4282-83a3-3365169a9b18">

## Out of scope

The content is overflowing vertically, too, but I wouldn't consider that an issue. The user should be used to scrolling up and down. Also, the whole form and the CTA button are above the fold.