### PR TITLE
feat: Add new public method `openCheckoutWindow`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -256,6 +256,14 @@ export class Supertab {
     return null;
   }
 
+  openCheckoutWindow() {
+    return openBlankChildWindow({
+      width: 488,
+      height: 800,
+      target: "supertabCheckout",
+    });
+  }
+
   @authenticated
   async payTab(
     id: string,
@@ -263,11 +271,7 @@ export class Supertab {
     | { status: "success"; tab: FormattedTab }
     | { status: "error"; error: string }
   > {
-    const checkoutWindow = openBlankChildWindow({
-      width: 488,
-      height: 800,
-      target: "supertabCheckout",
-    });
+    const checkoutWindow = this.openCheckoutWindow();
 
     const tab = await new TabsApi(this.tapperConfig).tabViewV1({
       tabId: id,


### PR DESCRIPTION
This method allows for a pragmatic fix of the popup blocker issue described in [CL-1535](https://laterpay.atlassian.net/browse/CL-1535). See [my recent comment on the ticket](https://laterpay.atlassian.net/browse/CL-1535?focusedCommentId=86427) for an explanation why I went with this pragmatic approach instead of the initial idea of creating a new method that combines the purchase and payment for "pay now" purchases.

The client (e.g. tab.js) can now call this method to open the checkout window right after the confirmation click and _before_ any network request is made. This way, the window should not be blocked by the browser.

The method `payTab` opens the checkout window again but as it's using the same name, it will simply reuse and focus the existing window.

[CL-1535]: https://laterpay.atlassian.net/browse/CL-1535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ