### PR TITLE
feat: Expose connected subscription offerings

### DIFF
--- a/__snapshots__/Supertab.test.ts.snap
+++ b/__snapshots__/Supertab.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Supertab .getOfferings return offerings with default currency 1`] = `
 [
   {
+    "connectedSubscriptionOffering": undefined,
     "description": "Test Offering Description",
     "id": "test-offering-id",
     "paymentModel": "pay_later",
@@ -22,6 +23,7 @@ exports[`Supertab .getOfferings return offerings with default currency 1`] = `
 exports[`Supertab .getOfferings with no existing tab return offerings with default currency 1`] = `
 [
   {
+    "connectedSubscriptionOffering": undefined,
     "description": "Test Offering Description",
     "id": "test-offering-id",
     "paymentModel": "pay_later",

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,8 @@ export class Supertab {
           prices,
           timePassDetails: eachOffering.timePassDetails,
           recurringDetails: eachOffering.recurringDetails,
+          connectedSubscriptionOffering:
+            eachOffering.connectedSubscriptionOffering,
         };
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,6 +195,7 @@ export class Supertab {
 
     const offerings = clientConfig.offerings
       .filter((eachOffering) => !!currenciesByCode[eachOffering.price.currency])
+      // Format all offerings
       .map((eachOffering) => {
         const prices = eachOffering.prices?.map((eachPrice) =>
           getPrice(eachOffering, eachPrice),
@@ -208,8 +209,27 @@ export class Supertab {
           prices,
           timePassDetails: eachOffering.timePassDetails,
           recurringDetails: eachOffering.recurringDetails,
-          connectedSubscriptionOffering:
-            eachOffering.connectedSubscriptionOffering,
+          // Temporarily store the connected subscription offering id (for the next step)
+          connectedSubscriptionOfferingId:
+            eachOffering.connectedSubscriptionOffering?.id,
+        };
+      })
+      // Add potential connected subscription offerings
+      .map((eachOffering, _, offerings) => {
+        // Find and return the formatted connected subscription offering
+        const connectedSubscriptionOffering =
+          eachOffering.connectedSubscriptionOfferingId
+            ? offerings.find(
+                (offering) =>
+                  offering.id === eachOffering.connectedSubscriptionOfferingId,
+              )
+            : undefined;
+        // Remove the temporary property from the offering
+        delete eachOffering.connectedSubscriptionOfferingId;
+        // Return the offering with the connected subscription offering
+        return {
+          ...eachOffering,
+          connectedSubscriptionOffering,
         };
       });
 


### PR DESCRIPTION
Ref: https://laterpay.atlassian.net/browse/CL-1568

## Overview

- This PR adds the property `connectedSubscriptionOffering` to the offerings returned by the method `getOfferings`.
- This is required in order to render the TimePass-Subscription relationships in the basic PayGate experience just like in the COW.
