### PR TITLE
Switch back to Hydra auth endpoint STG

### DIFF
--- a/tsup.stg.config.ts
+++ b/tsup.stg.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   minify: false,
   splitting: true,
   env: {
-    AUTH_URL: "https://signon.stg.supertab.co/oauth2/auth",
+    AUTH_URL: "https://auth.stg.supertab.co/oauth2/auth",
     TOKEN_URL: "https://auth.stg.supetab.co/oauth2/token",
     SSO_BASE_URL: "https://signon.stg.supertab.co",
     TAPI_BASE_URL: "https://tapi.stg.supertab.co",


### PR DESCRIPTION
## Jira Ticket

https://laterpay.atlassian.net/browse/SET-2361

## Context

Now that Hydra on STG is configured with the supertab.co domain
(see https://github.com/laterpay/terraform-lpeu-stg-tapper-auth/pull/12)
we can switch back to the original auth endpoint on Hydra
instead of the hacky SSO auth endpoint.

See more at https://github.com/laterpay/tapper-sso/pull/1368.

https://laterpay.atlassian.net/wiki/spaces/~835572784/pages/3194945538/Getting+rid+of+laterpay+from+the+Supertab+system#COW

## Proposed Solution

Switch from `https://signon.stg.supertab.co/oauth2/auth`
to `https://auth.stg.supertab.co/oauth2/auth`
