### PR TITLE
Switch back to Hydra auth endpoint on SBX

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,4 @@
-AUTH_URL=https://signon.sbx.supertab.co/oauth2/auth
+AUTH_URL=https://auth.sbx.supertab.co/oauth2/auth
 TOKEN_URL=https://auth.sbx.supertab.co/oauth2/token
 SSO_BASE_URL=https://signon.sbx.supertab.co
 TAPI_BASE_URL=https://tapi.sbx.supertab.co

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,4 @@
-AUTH_URL=https://signon.sbx.supertab.co/oauth2/auth
+AUTH_URL=https://auth.sbx.supertab.co/oauth2/auth
 TOKEN_URL=https://auth.sbx.supertab.co/oauth2/token
 SSO_BASE_URL=https://signon.sbx.supertab.co
 TAPI_BASE_URL=https://tapi.sbx.supertab.co

--- a/tsup.sbx.config.ts
+++ b/tsup.sbx.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   minify: false,
   splitting: true,
   env: {
-    AUTH_URL: "https://signon.sbx.supertab.co/oauth2/auth",
+    AUTH_URL: "https://auth.sbx.supertab.co/oauth2/auth",
     TOKEN_URL: "https://auth.sbx.supertab.co/oauth2/token",
     SSO_BASE_URL: "https://signon.sbx.supertab.co",
     TAPI_BASE_URL: "https://tapi.sbx.supertab.co",


### PR DESCRIPTION
## Jira Ticket

https://laterpay.atlassian.net/browse/SET-2361

## Context

Now that Hydra on SBX is configured with the supertab.co domain
(see https://github.com/laterpay/terraform-lpeu-sbx-tapper-auth/pull/32)
we can switch back to the original auth endpoint on Hydra
instead of the hacky SSO auth endpoint.

See more at https://github.com/laterpay/tapper-sso/pull/1368.

https://laterpay.atlassian.net/wiki/spaces/~835572784/pages/3194945538/Getting+rid+of+laterpay+from+the+Supertab+system#COW

## Proposed Solution

Switch from `https://signon.sbx.supertab.co/oauth2/auth`
to `https://auth.sbx.supertab.co/oauth2/auth`
