### PR TITLE
Switch to supertab.co domain on PROD

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
-AUTH_URL=https://auth.laterpay.net/oauth2/auth
-TOKEN_URL=https://auth.laterpay.net/oauth2/token
+AUTH_URL=https://signon.supertab.co/oauth2/auth
+TOKEN_URL=https://auth.supertab.co/oauth2/token
 SSO_BASE_URL=https://signon.supertab.co
-TAPI_BASE_URL=https://tapi.laterpay.net
+TAPI_BASE_URL=https://tapi.supertab.co
 CHECKOUT_BASE_URL=https://checkout.supertab.co

--- a/tsup.prod.config.ts
+++ b/tsup.prod.config.ts
@@ -11,10 +11,10 @@ export default defineConfig({
   minify: true,
   splitting: true,
   env: {
-    AUTH_URL: "https://auth.laterpay.net/oauth2/auth",
-    TOKEN_URL: "https://auth.laterpay.net/oauth2/token",
+    AUTH_URL: "https://signon.supertab.co/oauth2/auth",
+    TOKEN_URL: "https://auth.supertab.co/oauth2/token",
     SSO_BASE_URL: "https://signon.supertab.co",
-    TAPI_BASE_URL: "https://tapi.laterpay.net",
+    TAPI_BASE_URL: "https://tapi.supertab.co",
     CHECKOUT_BASE_URL: "https://checkout.supertab.co",
   },
   noExternal: ["zod", "@getsupertab/tapper-sdk"],


### PR DESCRIPTION
## Context

https://laterpay.atlassian.net/browse/SET-2361

https://laterpay.atlassian.net/wiki/spaces/~835572784/pages/3194945538/Getting+rid+of+laterpay+from+the+Supertab+system

One of the final steps in the process of cleaning up old `laterpay` name.
