### PR TITLE
Switch back to Hydra auth endpoint on PROD

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-AUTH_URL=https://signon.supertab.co/oauth2/auth
+AUTH_URL=https://auth.supertab.co/oauth2/auth
 TOKEN_URL=https://auth.supertab.co/oauth2/token
 SSO_BASE_URL=https://signon.supertab.co
 TAPI_BASE_URL=https://tapi.supertab.co

--- a/tsup.prod.config.ts
+++ b/tsup.prod.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   minify: true,
   splitting: true,
   env: {
-    AUTH_URL: "https://signon.supertab.co/oauth2/auth",
+    AUTH_URL: "https://auth.supertab.co/oauth2/auth",
     TOKEN_URL: "https://auth.supertab.co/oauth2/token",
     SSO_BASE_URL: "https://signon.supertab.co",
     TAPI_BASE_URL: "https://tapi.supertab.co",


### PR DESCRIPTION
## Jira Ticket

https://laterpay.atlassian.net/browse/SET-2361

## Context

Now that Hydra on PROD is configured with the supertab.co domain
(see https://github.com/laterpay/terraform-lpeu-prod-tapper-auth/pull/20)
we can switch back to the original auth endpoint on Hydra
instead of the hacky SSO auth endpoint.

See more at https://github.com/laterpay/tapper-sso/pull/1368.

https://laterpay.atlassian.net/wiki/spaces/~835572784/pages/3194945538/Getting+rid+of+laterpay+from+the+Supertab+system#COW

## Proposed Solution

Switch from `https://signon.supertab.co/oauth2/auth`
to `https://auth.supertab.co/oauth2/auth`

