### PR TITLE
feature: Include more currency details in offerings and tabs

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -174,6 +174,10 @@ describe("Supertab", () => {
         deletedAt: new Date("2021-01-01T00:00:00.000Z"),
         active: true,
         isEmailVerified: true,
+        email: "user@example.com",
+        registrationOrigin: "supertab",
+        isSuperuser: false,
+        tabCurrency: "USD",
       };
 
       server.withCurrentUser(user);

--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -672,7 +672,10 @@ describe("Supertab", () => {
             amount: 500,
             text: "$5",
           },
-          currency: "USD",
+          currency: {
+            isoCode: "USD",
+            baseUnit: 100,
+          },
           paymentModel: "pay_later",
           purchases: [
             {
@@ -682,7 +685,10 @@ describe("Supertab", () => {
               validTo: null,
               price: {
                 amount: 50,
-                currency: "USD",
+                currency: {
+                  isoCode: "USD",
+                  baseUnit: 100,
+                },
                 text: "$0.50",
               },
             },
@@ -993,7 +999,10 @@ describe("Supertab", () => {
       ).toEqual({
         itemAdded: true,
         tab: {
-          currency: "USD",
+          currency: {
+            isoCode: "USD",
+            baseUnit: 100,
+          },
           id: "test-tab-id",
           paymentModel: "pay_later",
           limit: {
@@ -1004,7 +1013,10 @@ describe("Supertab", () => {
             {
               price: {
                 amount: 50,
-                currency: "USD",
+                currency: {
+                  isoCode: "USD",
+                  baseUnit: 100,
+                },
                 text: "$0.50",
               },
               purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
@@ -1047,7 +1059,10 @@ describe("Supertab", () => {
       ).toEqual({
         itemAdded: true,
         tab: {
-          currency: "EUR",
+          currency: {
+            isoCode: "EUR",
+            baseUnit: 100,
+          },
           id: "test-tab-id",
           paymentModel: "pay_later",
           limit: {
@@ -1058,7 +1073,10 @@ describe("Supertab", () => {
             {
               price: {
                 amount: 50,
-                currency: "USD",
+                currency: {
+                  isoCode: "EUR",
+                  baseUnit: 100,
+                },
                 text: "€0.50",
               },
               purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
@@ -1090,17 +1108,17 @@ describe("Supertab", () => {
         detail: {
           itemAdded: true,
         },
-        tab: {
-          ...tabData,
-          currency: "BRL",
-        },
+        tab: createTabData("BRL"),
       });
 
       expect(await client.purchase({ offeringId: "test-offering-id" })).toEqual(
         {
           itemAdded: true,
           tab: {
-            currency: "BRL",
+            currency: {
+              isoCode: "BRL",
+              baseUnit: 100,
+            },
             id: "test-tab-id",
             limit: {
               amount: 500,
@@ -1111,7 +1129,10 @@ describe("Supertab", () => {
               {
                 price: {
                   amount: 50,
-                  currency: "USD",
+                  currency: {
+                    isoCode: "BRL",
+                    baseUnit: 100,
+                  },
                   text: "R$0.50",
                 },
                 purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
@@ -1159,7 +1180,10 @@ describe("Supertab", () => {
       ).toEqual({
         itemAdded: false,
         tab: {
-          currency: "USD",
+          currency: {
+            isoCode: "USD",
+            baseUnit: 100,
+          },
           id: "test-tab-id",
           paymentModel: "pay_later",
           limit: {
@@ -1170,7 +1194,10 @@ describe("Supertab", () => {
             {
               price: {
                 amount: 50,
-                currency: "USD",
+                currency: {
+                  isoCode: "USD",
+                  baseUnit: 100,
+                },
                 text: "$0.50",
               },
               purchaseDate: new Date("2023-11-03T15:34:44.852Z"),

--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -190,17 +190,26 @@ describe("Supertab", () => {
     const prices = [
       {
         amount: 100,
-        currency: "USD",
+        currency: {
+          isoCode: "USD",
+          baseUnit: 100,
+        },
         text: "$1.00",
       },
       {
         amount: 100,
-        currency: "EUR",
+        currency: {
+          isoCode: "EUR",
+          baseUnit: 100,
+        },
         text: "€1.00",
       },
       {
         amount: 100,
-        currency: "BRL",
+        currency: {
+          isoCode: "BRL",
+          baseUnit: 100,
+        },
         text: "R$1.00",
       },
     ];
@@ -241,7 +250,10 @@ describe("Supertab", () => {
             paymentModel: "pay_later",
             price: {
               amount: 100,
-              currency: "EUR",
+              currency: {
+                isoCode: "EUR",
+                baseUnit: 100,
+              },
               text: "€1.00",
             },
             prices,
@@ -268,7 +280,10 @@ describe("Supertab", () => {
             paymentModel: "pay_later",
             price: {
               amount: 100,
-              currency: "USD",
+              currency: {
+                isoCode: "USD",
+                baseUnit: 100,
+              },
               text: "$1.00",
             },
             prices,
@@ -294,7 +309,10 @@ describe("Supertab", () => {
             paymentModel: "pay_later",
             price: {
               amount: 100,
-              currency: "BRL",
+              currency: {
+                isoCode: "BRL",
+                baseUnit: 100,
+              },
               text: "R$1.00",
             },
             prices,
@@ -389,7 +407,10 @@ describe("Supertab", () => {
             paymentModel: "pay_later",
             price: {
               amount: 100,
-              currency: "EUR",
+              currency: {
+                isoCode: "EUR",
+                baseUnit: 100,
+              },
               text: "€1.00",
             },
             prices,
@@ -411,7 +432,10 @@ describe("Supertab", () => {
             paymentModel: "pay_later",
             price: {
               amount: 100,
-              currency: "EUR",
+              currency: {
+                isoCode: "EUR",
+                baseUnit: 100,
+              },
               text: "€1.00",
             },
             prices,
@@ -435,7 +459,10 @@ describe("Supertab", () => {
             paymentModel: "pay_later",
             price: {
               amount: 100,
-              currency: "EUR",
+              currency: {
+                isoCode: "EUR",
+                baseUnit: 100,
+              },
               text: "€1.00",
             },
             prices,

--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -910,61 +910,63 @@ describe("Supertab", () => {
   });
 
   describe(".purchase", () => {
-    const tabData: TabResponsePurchaseEnhanced = {
-      id: "test-tab-id",
-      guestEmail: null,
-      createdAt: new Date("2023-11-03T15:34:44.852Z"),
-      updatedAt: new Date("2023-11-03T15:34:44.852Z"),
-      merchantId: "test-merchant-id",
-      userId: "test-user-id",
-      status: "open",
-      paidAt: null,
-      total: 50,
-      limit: 500,
-      currency: "USD",
-      paymentModel: "pay_later",
-      purchases: [
-        {
-          id: "purchase.4df706b5-297a-49c5-a4cd-2a10eca12ff9",
-          createdAt: new Date("2023-11-03T15:34:44.852Z"),
-          updatedAt: new Date("2023-11-03T15:34:44.852Z"),
-          purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
-          merchantId: "test-merchant-id",
-          summary: "test-summary",
-          price: {
-            amount: 50,
-            currency: "USD",
+    function createTabData(currency: string): TabResponsePurchaseEnhanced {
+      return {
+        id: "test-tab-id",
+        guestEmail: null,
+        createdAt: new Date("2023-11-03T15:34:44.852Z"),
+        updatedAt: new Date("2023-11-03T15:34:44.852Z"),
+        merchantId: "test-merchant-id",
+        userId: "test-user-id",
+        status: "open",
+        paidAt: null,
+        total: 50,
+        limit: 500,
+        currency,
+        paymentModel: "pay_later",
+        purchases: [
+          {
+            id: "purchase.4df706b5-297a-49c5-a4cd-2a10eca12ff9",
+            createdAt: new Date("2023-11-03T15:34:44.852Z"),
+            updatedAt: new Date("2023-11-03T15:34:44.852Z"),
+            purchaseDate: new Date("2023-11-03T15:34:44.852Z"),
+            merchantId: "test-merchant-id",
+            summary: "test-summary",
+            price: {
+              amount: 50,
+              currency,
+            },
+            salesModel: "time_pass",
+            paymentModel: "pay_later",
+            metadata: {
+              additionalProp1: {},
+              additionalProp2: {},
+              additionalProp3: {},
+            },
+            attributedTo: "test-id",
+            offeringId: "test-offering-id",
+            contentKey: "test-content-key",
+            testMode: false,
+            validFrom: null,
+            validTo: null,
+            validTimedelta: null,
+            recurringDetails: null,
+            merchantName: "test-merchant-name",
           },
-          salesModel: "time_pass",
-          paymentModel: "pay_later",
-          metadata: {
-            additionalProp1: {},
-            additionalProp2: {},
-            additionalProp3: {},
-          },
-          attributedTo: "test-id",
-          offeringId: "test-offering-id",
-          contentKey: "test-content-key",
-          testMode: false,
-          validFrom: null,
-          validTo: null,
-          validTimedelta: null,
-          recurringDetails: null,
-          merchantName: "test-merchant-name",
+        ],
+        metadata: {
+          additionalProp1: {},
+          additionalProp2: {},
+          additionalProp3: {},
         },
-      ],
-      metadata: {
-        additionalProp1: {},
-        additionalProp2: {},
-        additionalProp3: {},
-      },
-      testMode: false,
-      tabStatistics: {
-        purchasesCount: 0,
-        obfuscatedPurchasesCount: 0,
-        obfuscatedPurchasesTotal: 0,
-      },
-    };
+        testMode: false,
+        tabStatistics: {
+          purchasesCount: 0,
+          obfuscatedPurchasesCount: 0,
+          obfuscatedPurchasesTotal: 0,
+        },
+      };
+    }
 
     const tabMetaData = {
       count: 1,
@@ -980,7 +982,7 @@ describe("Supertab", () => {
       const { client } = setup();
 
       server.withGetTab({
-        data: [tabData],
+        data: [createTabData("USD")],
         metadata: tabMetaData,
       });
 
@@ -988,7 +990,7 @@ describe("Supertab", () => {
         detail: {
           itemAdded: true,
         },
-        tab: tabData,
+        tab: createTabData("USD"),
       });
 
       expect(
@@ -1037,7 +1039,7 @@ describe("Supertab", () => {
     test("creates a purchase in tab currency if found no matter what is preferred currency", async () => {
       const { client } = setup();
 
-      const euroTabData = { ...tabData, currency: "EUR" };
+      const euroTabData = createTabData("EUR");
 
       server.withGetTab({
         data: [euroTabData],
@@ -1155,7 +1157,7 @@ describe("Supertab", () => {
       const { client } = setup();
 
       server.withGetTab({
-        data: [tabData],
+        data: [createTabData("USD")],
         metadata: tabMetaData,
       });
 
@@ -1165,7 +1167,7 @@ describe("Supertab", () => {
             itemAdded: false,
           },
           tab: {
-            ...tabData,
+            ...createTabData("USD"),
             status: TabStatus.Full,
           },
         },
@@ -1219,7 +1221,7 @@ describe("Supertab", () => {
       const { client } = setup();
 
       server.withGetTab({
-        data: [tabData],
+        data: [createTabData("USD")],
         metadata: tabMetaData,
       });
 

--- a/__snapshots__/Supertab.test.ts.snap
+++ b/__snapshots__/Supertab.test.ts.snap
@@ -1,41 +1,5 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Supertab .getOfferings return offerings with default currency 1`] = `
-[
-  {
-    "connectedSubscriptionOffering": undefined,
-    "description": "Test Offering Description",
-    "id": "test-offering-id",
-    "paymentModel": "pay_later",
-    "price": {
-      "amount": 100,
-      "currency": "USD",
-      "text": "$1.00",
-    },
-    "prices": [
-      {
-        "amount": 100,
-        "currency": "USD",
-        "text": "$1.00",
-      },
-      {
-        "amount": 100,
-        "currency": "EUR",
-        "text": "€1.00",
-      },
-      {
-        "amount": 100,
-        "currency": "BRL",
-        "text": "R$1.00",
-      },
-    ],
-    "recurringDetails": null,
-    "salesModel": "time_pass",
-    "timePassDetails": null,
-  },
-]
-`;
-
 exports[`Supertab .getOfferings with no existing tab return offerings with default currency 1`] = `
 [
   {
@@ -45,23 +9,35 @@ exports[`Supertab .getOfferings with no existing tab return offerings with defau
     "paymentModel": "pay_later",
     "price": {
       "amount": 100,
-      "currency": "USD",
+      "currency": {
+        "baseUnit": 100,
+        "isoCode": "USD",
+      },
       "text": "$1.00",
     },
     "prices": [
       {
         "amount": 100,
-        "currency": "USD",
+        "currency": {
+          "baseUnit": 100,
+          "isoCode": "USD",
+        },
         "text": "$1.00",
       },
       {
         "amount": 100,
-        "currency": "EUR",
+        "currency": {
+          "baseUnit": 100,
+          "isoCode": "EUR",
+        },
         "text": "€1.00",
       },
       {
         "amount": 100,
-        "currency": "BRL",
+        "currency": {
+          "baseUnit": 100,
+          "isoCode": "BRL",
+        },
         "text": "R$1.00",
       },
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,8 +411,8 @@ export class Supertab {
 
     return formatPrice({
       amount,
-      currency: currencyObject?.isoCode ?? "",
-      baseUnit: currencyObject?.baseUnit ?? 100,
+      currency: currencyObject.isoCode,
+      baseUnit: currencyObject.baseUnit,
       localeCode: this.language,
       showZeroFractionDigits: true,
       showSymbol: true,
@@ -435,8 +435,8 @@ export class Supertab {
     const priceToText = (amount: number) =>
       formatPrice({
         amount,
-        currency: currencyObject.isoCode ?? "",
-        baseUnit: currencyObject.baseUnit ?? 100,
+        currency: currencyObject.isoCode,
+        baseUnit: currencyObject.baseUnit,
         localeCode: this.language,
         showZeroFractionDigits: false,
         showSymbol: currencyObject.isoCode !== "CHF",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,13 @@ import {
 
 import { authFlow, getAuthStatus, getAccessToken, AuthStatus } from "./auth";
 import { DEFAULT_CURRENCY, formatPrice } from "./price";
-import { Authenticable, FormattedTab, ScreenHint, SystemUrls } from "./types";
+import {
+  Authenticable,
+  FormattedTab,
+  PublicCurrencyDetails,
+  ScreenHint,
+  SystemUrls,
+} from "./types";
 import { handleChildWindow, openBlankChildWindow } from "./window";
 
 function authenticated(
@@ -186,7 +192,7 @@ export class Supertab {
 
       return {
         amount: offering.price.amount,
-        currency: currency.isoCode,
+        currency: getPublicCurrencyDetails(currency),
         text,
       };
     };
@@ -462,4 +468,11 @@ export class Supertab {
     };
     return formattedTab;
   }
+}
+
+function getPublicCurrencyDetails(currency: Currency): PublicCurrencyDetails {
+  return {
+    isoCode: currency.isoCode,
+    baseUnit: currency.baseUnit,
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Currency } from "@getsupertab/tapper-sdk";
 import { Supertab } from ".";
 import { AuthStatus } from "./auth";
 
@@ -18,3 +19,5 @@ export interface SystemUrls {
 export type FormattedTab = Awaited<
   ReturnType<typeof Supertab.prototype.formatTab>
 >;
+
+export type PublicCurrencyDetails = Pick<Currency, "isoCode" | "baseUnit">;

--- a/tsup.stg.config.ts
+++ b/tsup.stg.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   splitting: true,
   env: {
     AUTH_URL: "https://auth.stg.supertab.co/oauth2/auth",
-    TOKEN_URL: "https://auth.stg.supetab.co/oauth2/token",
+    TOKEN_URL: "https://auth.stg.supertab.co/oauth2/token",
     SSO_BASE_URL: "https://signon.stg.supertab.co",
     TAPI_BASE_URL: "https://tapi.stg.supertab.co",
     CHECKOUT_BASE_URL: "https://checkout.stg.supertab.co",


### PR DESCRIPTION
BREAKING CHANGE: Change currency type from `string` (isoCode) to `object` (isoCode, baseUnit)

## Details

Offerings, tabs and tab purchases now contain more currency details in the form of an object. Before, they contained just the currency iso code string.

```typescript
type PublicCurrencyDetails = Pick<Currency, "isoCode" | "baseUnit">;

// Example
const currency: PublicCurrencyDetails = {
  isoCode: "USD",
  baseUnit: 100,
};
```

## Why

We're implementing Google's Monetization Provider API for experiences.js and we need to know the currency's base unit for the response data.

## Changes

- **fix: Correct typo in STG token URL**
- **Add missing data to mock user**
- **Include currency isoCode and baseUnit in offerings**
- **Include currency iso code and base unit in tabs**
- **Fix inconsitent currency handling in test mock api**
