### PR TITLE
feat: add `getCurrencyDetails` method

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -256,6 +256,22 @@ const setup = ({
         createdAt: new Date("2021-01-01T00:00:00.000Z"),
         updatedAt: new Date("2021-01-01T00:00:00.000Z"),
       },
+      {
+        id: "chf-currency",
+        name: "Swiss Franc",
+        symbol: "",
+        isMainCurrency: false,
+        operationalStatus: CurrencyOperationalStatus.Active,
+        tabLimit: 500,
+        firstTabLimit: 100,
+        googlePayoutsEnabled: false,
+        exchangeRate: 1,
+        roundingRule: CurrencyRoundingRule.Hundredth,
+        isoCode: "CHF",
+        baseUnit: 100,
+        createdAt: new Date("2021-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2021-01-01T00:00:00.000Z"),
+      },
     ] as Currency[],
     suggestedCurrency: clientConfigProps?.suggestedCurrency ?? "USD",
   } as ClientExperiencesConfig);
@@ -1523,6 +1539,89 @@ describe("Supertab", () => {
 
         expect(experience?.offerings[0].price.currency.isoCode).toBe("BRL");
         expect(experience?.offerings[0].price.text).toBe("R$1.00");
+      });
+    });
+  });
+
+  describe(".getCurrencyDetails", () => {
+    test("returns currency details for valid ISO code", async () => {
+      const { client } = setup();
+
+      const result = await client.getCurrencyDetails("USD");
+
+      expect(result).toEqual({
+        isoCode: "USD",
+        name: "US Dollar",
+        symbol: "$",
+        baseUnit: 100,
+        firstTabLimit: {
+          amount: 100,
+          text: "$1",
+        },
+        tabLimit: {
+          amount: 500,
+          text: "$5",
+        },
+      });
+    });
+
+    test("returns null for invalid ISO code", async () => {
+      const { client } = setup();
+
+      const result = await client.getCurrencyDetails("INVALID");
+
+      expect(result).toBeNull();
+    });
+
+    test("uses suggested currency when no ISO code provided", async () => {
+      const { client } = setup({
+        clientConfigProps: { suggestedCurrency: "EUR" },
+      });
+
+      const result = await client.getCurrencyDetails("");
+
+      expect(result?.isoCode).toBe("EUR");
+    });
+
+    test("formats tab limits based on locale", async () => {
+      const { client } = setup({ language: "de-DE" });
+
+      const result = await client.getCurrencyDetails("EUR");
+
+      expect(result).toEqual({
+        isoCode: "EUR",
+        name: "Euro",
+        symbol: "€",
+        baseUnit: 100,
+        firstTabLimit: {
+          amount: 100,
+          text: "1\u00A0€",
+        },
+        tabLimit: {
+          amount: 500,
+          text: "5\u00A0€",
+        },
+      });
+    });
+
+    test("formats CHF without currency symbol", async () => {
+      const { client } = setup();
+
+      const result = await client.getCurrencyDetails("CHF");
+
+      expect(result).toEqual({
+        isoCode: "CHF",
+        name: "Swiss Franc",
+        symbol: "",
+        baseUnit: 100,
+        firstTabLimit: {
+          amount: 100,
+          text: "CHF\u00A01",
+        },
+        tabLimit: {
+          amount: 500,
+          text: "CHF\u00A05",
+        },
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -534,4 +534,45 @@ export class Supertab {
       siteLogoUrl,
     };
   }
+
+  async getCurrencyDetails(isoCode: string) {
+    const experiencesConfig = await this.#getClientExperiencesConfig();
+
+    if (!isoCode) {
+      isoCode = experiencesConfig.suggestedCurrency || DEFAULT_CURRENCY;
+    }
+
+    const currency = experiencesConfig.currencies.find(
+      (currency) => currency.isoCode === isoCode,
+    );
+
+    if (!currency) {
+      return null;
+    }
+
+    const formatTabLimit = (amount: number) =>
+      formatPrice({
+        amount,
+        currency: currency.isoCode,
+        baseUnit: currency.baseUnit,
+        localeCode: this.language,
+        showZeroFractionDigits: false,
+        showSymbol: currency.isoCode !== "CHF",
+      });
+
+    return {
+      isoCode: currency.isoCode,
+      name: currency.name,
+      symbol: currency.symbol,
+      baseUnit: currency.baseUnit,
+      firstTabLimit: {
+        amount: currency.firstTabLimit,
+        text: formatTabLimit(currency.firstTabLimit ?? 100),
+      },
+      tabLimit: {
+        amount: currency.tabLimit,
+        text: formatTabLimit(currency.tabLimit ?? 500),
+      },
+    };
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -560,6 +560,9 @@ export class Supertab {
         showSymbol: currency.isoCode !== "CHF",
       });
 
+    const DEFAULT_FIRST_TAB_LIMIT = 100;
+    const DEFAULT_TAB_LIMIT = 500;
+
     return {
       isoCode: currency.isoCode,
       name: currency.name,
@@ -567,11 +570,11 @@ export class Supertab {
       baseUnit: currency.baseUnit,
       firstTabLimit: {
         amount: currency.firstTabLimit,
-        text: formatTabLimit(currency.firstTabLimit ?? 100),
+        text: formatTabLimit(currency.firstTabLimit ?? DEFAULT_FIRST_TAB_LIMIT),
       },
       tabLimit: {
         amount: currency.tabLimit,
-        text: formatTabLimit(currency.tabLimit ?? 500),
+        text: formatTabLimit(currency.tabLimit ?? DEFAULT_TAB_LIMIT),
       },
     };
   }

--- a/src/window.ts
+++ b/src/window.ts
@@ -1,7 +1,7 @@
-//const loadOmegaAnimation = async () => {
-//  const { default: omegaAnimation } = await import("./omegaAnimation");
-//  return omegaAnimation;
-//};
+const loadOmegaAnimation = async () => {
+  const { default: omegaAnimation } = await import("./omegaAnimation");
+  return omegaAnimation;
+};
 
 export const handleChildWindow = async <T>({
   url,
@@ -31,9 +31,7 @@ export const handleChildWindow = async <T>({
   const isUrlOpened = openedWindow.location.href === url.toString();
 
   if (!isUrlOpened) {
-    fetch(url.toString())
-      .then(setWindowLocation)
-      .catch(() => setWindowLocation());
+    setWindowLocation();
   }
 
   let receivedPostMessage = false;
@@ -85,48 +83,48 @@ export const openBlankChildWindow = ({
     target ?? "_blank",
     windowFeatures,
   );
-  //let newWindowDocument = null;
+  let newWindowDocument = null;
 
-  //try {
-  //  newWindowDocument = newWindow?.document;
-  //  // eslint-disable-next-line
-  //} catch (e) {}
+  try {
+    newWindowDocument = newWindow?.document;
+    // eslint-disable-next-line
+  } catch (e) {}
 
-  //if (newWindowDocument) {
-  //  newWindowDocument.write(
-  //    '<html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"><title>Supertab</title></head>'
-  //  );
-  //  newWindowDocument.close();
+  if (newWindowDocument) {
+    newWindowDocument.write(
+      '<html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"><title>Supertab</title></head>',
+    );
+    newWindowDocument.close();
 
-  //  loadOmegaAnimation()
-  //    .then((omegaAnimation) => {
-  //      if (
-  //        newWindowDocument &&
-  //        newWindowDocument.getElementById("supertab-loading-animation") ===
-  //          null
-  //      ) {
-  //        const container = newWindowDocument.createElement("div");
-  //        container.id = "supertab-loading-animation";
-  //        container.style.cssText =
-  //          "display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%";
+    loadOmegaAnimation()
+      .then((omegaAnimation) => {
+        if (
+          newWindowDocument &&
+          newWindowDocument.getElementById("supertab-loading-animation") ===
+            null
+        ) {
+          const container = newWindowDocument.createElement("div");
+          container.id = "supertab-loading-animation";
+          container.style.cssText =
+            "display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%";
 
-  //        const img = newWindowDocument.createElement("img");
-  //        img.src = omegaAnimation;
-  //        img.style.cssText = "width: 180px; height: auto";
+          const img = newWindowDocument.createElement("img");
+          img.src = omegaAnimation;
+          img.style.cssText = "width: 180px; height: auto";
 
-  //        const text = newWindowDocument.createElement("p");
-  //        text.style.cssText =
-  //          "margin-top: -10px; font-size: 16px; font-weight: 400; color: #555; font-family: Helvetica";
-  //        text.textContent = "Loading your Supertab...";
+          const text = newWindowDocument.createElement("p");
+          text.style.cssText =
+            "margin-top: -10px; font-size: 16px; font-weight: 400; color: #555; font-family: Helvetica";
+          text.textContent = "Loading your Supertab...";
 
-  //        container.appendChild(img);
-  //        container.appendChild(text);
-  //        newWindowDocument.body.appendChild(container);
-  //      }
-  //    })
-  //    // eslint-disable-next-line
-  //    .catch((e) => {});
-  //}
+          container.appendChild(img);
+          container.appendChild(text);
+          newWindowDocument.body.appendChild(container);
+        }
+      })
+      // eslint-disable-next-line
+      .catch((e) => {});
+  }
 
   return newWindow;
 };

--- a/src/window.ts
+++ b/src/window.ts
@@ -1,7 +1,7 @@
-const loadOmegaAnimation = async () => {
-  const { default: omegaAnimation } = await import("./omegaAnimation");
-  return omegaAnimation;
-};
+//const loadOmegaAnimation = async () => {
+//  const { default: omegaAnimation } = await import("./omegaAnimation");
+//  return omegaAnimation;
+//};
 
 export const handleChildWindow = async <T>({
   url,
@@ -31,7 +31,9 @@ export const handleChildWindow = async <T>({
   const isUrlOpened = openedWindow.location.href === url.toString();
 
   if (!isUrlOpened) {
-    setWindowLocation();
+    fetch(url.toString())
+      .then(setWindowLocation)
+      .catch(() => setWindowLocation());
   }
 
   let receivedPostMessage = false;
@@ -83,48 +85,48 @@ export const openBlankChildWindow = ({
     target ?? "_blank",
     windowFeatures,
   );
-  let newWindowDocument = null;
+  //let newWindowDocument = null;
 
-  try {
-    newWindowDocument = newWindow?.document;
-    // eslint-disable-next-line
-  } catch (e) {}
+  //try {
+  //  newWindowDocument = newWindow?.document;
+  //  // eslint-disable-next-line
+  //} catch (e) {}
 
-  if (newWindowDocument) {
-    newWindowDocument.write(
-      '<html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"><title>Supertab</title></head>',
-    );
-    newWindowDocument.close();
+  //if (newWindowDocument) {
+  //  newWindowDocument.write(
+  //    '<html><head><meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"><title>Supertab</title></head>'
+  //  );
+  //  newWindowDocument.close();
 
-    loadOmegaAnimation()
-      .then((omegaAnimation) => {
-        if (
-          newWindowDocument &&
-          newWindowDocument.getElementById("supertab-loading-animation") ===
-            null
-        ) {
-          const container = newWindowDocument.createElement("div");
-          container.id = "supertab-loading-animation";
-          container.style.cssText =
-            "display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%";
+  //  loadOmegaAnimation()
+  //    .then((omegaAnimation) => {
+  //      if (
+  //        newWindowDocument &&
+  //        newWindowDocument.getElementById("supertab-loading-animation") ===
+  //          null
+  //      ) {
+  //        const container = newWindowDocument.createElement("div");
+  //        container.id = "supertab-loading-animation";
+  //        container.style.cssText =
+  //          "display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%";
 
-          const img = newWindowDocument.createElement("img");
-          img.src = omegaAnimation;
-          img.style.cssText = "width: 180px; height: auto";
+  //        const img = newWindowDocument.createElement("img");
+  //        img.src = omegaAnimation;
+  //        img.style.cssText = "width: 180px; height: auto";
 
-          const text = newWindowDocument.createElement("p");
-          text.style.cssText =
-            "margin-top: -10px; font-size: 16px; font-weight: 400; color: #555; font-family: Helvetica";
-          text.textContent = "Loading your Supertab...";
+  //        const text = newWindowDocument.createElement("p");
+  //        text.style.cssText =
+  //          "margin-top: -10px; font-size: 16px; font-weight: 400; color: #555; font-family: Helvetica";
+  //        text.textContent = "Loading your Supertab...";
 
-          container.appendChild(img);
-          container.appendChild(text);
-          newWindowDocument.body.appendChild(container);
-        }
-      })
-      // eslint-disable-next-line
-      .catch((e) => {});
-  }
+  //        container.appendChild(img);
+  //        container.appendChild(text);
+  //        newWindowDocument.body.appendChild(container);
+  //      }
+  //    })
+  //    // eslint-disable-next-line
+  //    .catch((e) => {});
+  //}
 
   return newWindow;
 };


### PR DESCRIPTION
This PR adds `getCurrencyDetails` method to the browser SDK. The method is exposing currency properties, allowing integrations to access currency specific properties like `firstTabLimit` and `tabLimit`. This partially unblocks rendering the contextual help text "You only pay when your tab reaches X" where X is either regular tab limit or first tab limit.

## `.getCurrencyDetails()` arguments

* `isoCode`: `string` – passing valid currency ISO code will return currency details in a requested currency. Defaults to the suggested currency from the experiences config.

## `.getCurrencyDetails()` response type

```typescript
type GetCurrencyResponse = {
  isoCode: string;
  name: string;
  symbol: string;
  baseUnit: number;
  firstTabLimit: {
    amount: number;
    text: string;
  },
  tabLimit: {
    amount: number;
    text: string;
  }
}
```

## `.getCurrencyDetails()` response example

```js
{
  isoCode: "USD",
  name: "US Dollar",
  symbol: "$",
  baseUnit: 100,
  firstTabLimit: {
    amount: 100,
    text: "$1"
  },
  tabLimit: {
    amount: 500,
    text: "$5"
  }
}
```

## Checklist

* [x] Tests added

Ref: https://laterpay.atlassian.net/browse/CL-1777