### PR TITLE
fix: make `isoCode` in `getCurrencyDetails` optional

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -1715,7 +1715,7 @@ describe("Supertab", () => {
         clientConfigProps: { suggestedCurrency: "EUR" },
       });
 
-      const result = await client.getCurrencyDetails("");
+      const result = await client.getCurrencyDetails();
 
       expect(result?.isoCode).toBe("EUR");
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -562,7 +562,7 @@ export class Supertab {
     };
   }
 
-  async getCurrencyDetails(isoCode: string) {
+  async getCurrencyDetails(isoCode?: string) {
     const experiencesConfig = await this.#getClientExperiencesConfig();
 
     if (!isoCode) {


### PR DESCRIPTION
This PR makes `isoCode` function argument in `getCurrencyDetails` optional. It was intended to be optional originally but in #147 we mistakenly made it required.