### PR TITLE
feat: make `checkAccess` accept optional `contentKey` to check access for specific key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,11 +229,13 @@ export class Supertab {
   }
 
   @authenticated
-  async checkAccess() {
-    const clientConfig = await this.#getClientConfig();
-    const contentKey = clientConfig.contentKeys.map(
-      (item) => item.contentKey,
-    )[0] as string;
+  async checkAccess(contentKey?: string) {
+    if (!contentKey) {
+      const clientConfig = await this.#getClientConfig();
+      contentKey = clientConfig.contentKeys.map(
+        (item) => item.contentKey,
+      )[0] as string;
+    }
 
     const access = await new AccessApi(this.tapperConfig).checkAccessV2({
       contentKey,
@@ -242,6 +244,7 @@ export class Supertab {
     if (access.access) {
       return {
         access: {
+          contentKey: access.access.contentKey,
           validTo: access.access.validTo
             ? new Date(access.access.validTo * 1000)
             : undefined,


### PR DESCRIPTION
This PR adds optional `contentKey` argument to `checkAccess` function. It allows checking access by a specific content key, rather than the first content key found in the client config.

To keep the backwards compatibility, the function still looks up the first content key in the client config in case `contentKey` is not specified. This ensures the existing integrations won't break. This is because we will be moving away from client config entirely soon so the plan is to introduce one major version with all related breaking changes.

## Checklist

- [x] Tests added