### PR TITLE
fix: return correct price for preferred currency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export class Supertab {
       this.tapperConfig,
     ).getClientConfigV1({
       clientId: this.clientId,
+      currency: "INR",
     });
 
     return this._clientConfig;
@@ -186,6 +187,10 @@ export class Supertab {
           getPrice(eachPrice),
         );
 
+        const preferredCurrencyPrice = eachOffering.prices.find(
+          (price) => price.currency === presentedCurrency,
+        );
+
         let connectedSubscriptionOffering;
         // If the offering has a connected subscription offering, store the id
         // temporarily to be able to find the formatted connected subscription
@@ -201,7 +206,7 @@ export class Supertab {
           description: eachOffering.description,
           salesModel: eachOffering.salesModel,
           paymentModel: eachOffering.paymentModel,
-          price: getPrice(eachOffering.price, presentedCurrency),
+          price: getPrice(preferredCurrencyPrice!),
           prices,
           timePassDetails: eachOffering.timePassDetails,
           recurringDetails: eachOffering.recurringDetails,

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,6 @@ export class Supertab {
       this.tapperConfig,
     ).getClientConfigV1({
       clientId: this.clientId,
-      currency: "INR",
     });
 
     return this._clientConfig;


### PR DESCRIPTION
This PR fixes preferred currency price logic in `getOfferings` when setting `price` value. It's bringing it in line with how we handle it in `getExperience`.

The previous implementation led into issues for users with existing tabs in different currency. The `price` object was set to the currency of an existing tab, but the amount was set to the preferred currency that `getOfferings` accepts as an argument.

## Example

A user with tab in EUR visited a site calling `getOfferings` with `INR` as preferred currency. The price of the offering was set to 600 INR and 6 EUR. User was presented with `€600` instead of `₹600`.