### PR TITLE
fix: format upsell offerings in getExperience

### DIFF
--- a/Supertab.test.ts
+++ b/Supertab.test.ts
@@ -4,7 +4,7 @@ import EventEmitter from "events";
 import Supertab from ".";
 import {
   ClientConfig,
-  ClientExperiencesConfig,
+  ClientExperiencesConfigResponse,
   Currency,
   CurrencyOperationalStatus,
   CurrencyRoundingRule,
@@ -175,6 +175,7 @@ const setup = ({
         id: "test-offering-id",
         description: "Test Offering Description",
         salesModel: "time_pass",
+        productId: "test-product-id",
         paymentModel: "pay_later",
         suggestedCurrencyPrice: {
           amount: 100,
@@ -194,13 +195,68 @@ const setup = ({
             currency: "BRL",
           },
         ] as Price[],
-        recurringDetails: undefined,
+        recurringDetails: null,
         timePassDetails: {
           validTimedelta: "1d",
         },
       },
     ],
-    upsells: [],
+    upsells: [
+      {
+        mainOffering: {
+          id: "test-offering-id",
+          description: "Test Offering Description",
+          salesModel: "time_pass",
+          paymentModel: "pay_later",
+          productId: "test-product-id",
+          prices: [
+            {
+              amount: 100,
+              currency: "USD",
+            },
+            {
+              amount: 100,
+              currency: "EUR",
+            },
+            {
+              amount: 100,
+              currency: "BRL",
+            },
+          ] as Price[],
+          timePassDetails: {
+            validTimedelta: "1d",
+          },
+          recurringDetails: null,
+        },
+        upsellOffering: {
+          id: "test-offering-id",
+          description: "Test Offering Description",
+          salesModel: "subscription",
+          paymentModel: "pay_now",
+          productId: "test-product-id",
+          prices: [
+            {
+              amount: 100,
+              currency: "USD",
+            },
+            {
+              amount: 100,
+              currency: "EUR",
+            },
+            {
+              amount: 100,
+              currency: "BRL",
+            },
+          ] as Price[],
+          timePassDetails: null,
+          recurringDetails: {
+            billingInterval: "day",
+            intervalCount: 1,
+          },
+        },
+        discount: 0,
+      },
+    ],
   };
 
   const clientExperiencesConfig = {
@@ -277,7 +333,7 @@ const setup = ({
       },
     ] as Currency[],
     suggestedCurrency: clientConfigProps?.suggestedCurrency ?? "USD",
-  } as ClientExperiencesConfig;
+  } as ClientExperiencesConfigResponse;
 
   server.withClientExperiencesConfig(clientExperiencesConfig);
 
@@ -1624,6 +1680,12 @@ describe("Supertab", () => {
     test("returns null for non-existent experience id", async () => {
       const { client } = setup();
       expect(await client.getExperience({ id: "non-existent-id" })).toBeNull();
+    });
+
+    test("returns upsells", async () => {
+      const { client } = setup();
+
+      expect(await client.getExperience()).toMatchSnapshot();
     });
 
     describe("with no tab", () => {

--- a/__snapshots__/Supertab.test.ts.snap
+++ b/__snapshots__/Supertab.test.ts.snap
@@ -91,7 +91,7 @@ exports[`Supertab .getExperience return first experience if id is not supplied 1
           "text": "R$1.00",
         },
       ],
-      "recurringDetails": undefined,
+      "recurringDetails": null,
       "salesModel": "time_pass",
       "timePassDetails": {
         "validTimedelta": "1d",
@@ -106,7 +106,100 @@ exports[`Supertab .getExperience return first experience if id is not supplied 1
   },
   "type": "basic_paygate",
   "uiConfig": {},
-  "upsells": [],
+  "upsells": [
+    {
+      "discount": 0,
+      "mainOffering": {
+        "description": "Test Offering Description",
+        "id": "test-offering-id",
+        "paymentModel": "pay_later",
+        "price": {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "USD",
+          },
+          "text": "$1.00",
+        },
+        "prices": [
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "USD",
+            },
+            "text": "$1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "EUR",
+            },
+            "text": "€1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "BRL",
+            },
+            "text": "R$1.00",
+          },
+        ],
+        "recurringDetails": null,
+        "salesModel": "time_pass",
+        "timePassDetails": {
+          "validTimedelta": "1d",
+        },
+      },
+      "upsellOffering": {
+        "description": "Test Offering Description",
+        "id": "test-offering-id",
+        "paymentModel": "pay_now",
+        "price": {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "USD",
+          },
+          "text": "$1.00",
+        },
+        "prices": [
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "USD",
+            },
+            "text": "$1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "EUR",
+            },
+            "text": "€1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "BRL",
+            },
+            "text": "R$1.00",
+          },
+        ],
+        "recurringDetails": {
+          "billingInterval": "day",
+          "intervalCount": 1,
+        },
+        "salesModel": "subscription",
+        "timePassDetails": null,
+      },
+    },
+  ],
 }
 `;
 
@@ -153,7 +246,7 @@ exports[`Supertab .getExperience return experience by id 1`] = `
           "text": "R$1.00",
         },
       ],
-      "recurringDetails": undefined,
+      "recurringDetails": null,
       "salesModel": "time_pass",
       "timePassDetails": {
         "validTimedelta": "1d",
@@ -168,6 +261,254 @@ exports[`Supertab .getExperience return experience by id 1`] = `
   },
   "type": "basic_paygate",
   "uiConfig": {},
-  "upsells": [],
+  "upsells": [
+    {
+      "discount": 0,
+      "mainOffering": {
+        "description": "Test Offering Description",
+        "id": "test-offering-id",
+        "paymentModel": "pay_later",
+        "price": {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "USD",
+          },
+          "text": "$1.00",
+        },
+        "prices": [
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "USD",
+            },
+            "text": "$1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "EUR",
+            },
+            "text": "€1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "BRL",
+            },
+            "text": "R$1.00",
+          },
+        ],
+        "recurringDetails": null,
+        "salesModel": "time_pass",
+        "timePassDetails": {
+          "validTimedelta": "1d",
+        },
+      },
+      "upsellOffering": {
+        "description": "Test Offering Description",
+        "id": "test-offering-id",
+        "paymentModel": "pay_now",
+        "price": {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "USD",
+          },
+          "text": "$1.00",
+        },
+        "prices": [
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "USD",
+            },
+            "text": "$1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "EUR",
+            },
+            "text": "€1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "BRL",
+            },
+            "text": "R$1.00",
+          },
+        ],
+        "recurringDetails": {
+          "billingInterval": "day",
+          "intervalCount": 1,
+        },
+        "salesModel": "subscription",
+        "timePassDetails": null,
+      },
+    },
+  ],
+}
+`;
+
+exports[`Supertab .getExperience returns upsells 1`] = `
+{
+  "id": "test-experience-1",
+  "name": "My Experience",
+  "offerings": [
+    {
+      "description": "Test Offering Description",
+      "id": "test-offering-id",
+      "paymentModel": "pay_later",
+      "price": {
+        "amount": 100,
+        "currency": {
+          "baseUnit": 100,
+          "isoCode": "USD",
+        },
+        "text": "$1.00",
+      },
+      "prices": [
+        {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "USD",
+          },
+          "text": "$1.00",
+        },
+        {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "EUR",
+          },
+          "text": "€1.00",
+        },
+        {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "BRL",
+          },
+          "text": "R$1.00",
+        },
+      ],
+      "recurringDetails": null,
+      "salesModel": "time_pass",
+      "timePassDetails": {
+        "validTimedelta": "1d",
+      },
+    },
+  ],
+  "product": {
+    "contentKey": "test-content-key",
+    "contentKeyRequired": true,
+    "id": "test-product",
+    "name": "Test Product",
+  },
+  "type": "basic_paygate",
+  "uiConfig": {},
+  "upsells": [
+    {
+      "discount": 0,
+      "mainOffering": {
+        "description": "Test Offering Description",
+        "id": "test-offering-id",
+        "paymentModel": "pay_later",
+        "price": {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "USD",
+          },
+          "text": "$1.00",
+        },
+        "prices": [
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "USD",
+            },
+            "text": "$1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "EUR",
+            },
+            "text": "€1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "BRL",
+            },
+            "text": "R$1.00",
+          },
+        ],
+        "recurringDetails": null,
+        "salesModel": "time_pass",
+        "timePassDetails": {
+          "validTimedelta": "1d",
+        },
+      },
+      "upsellOffering": {
+        "description": "Test Offering Description",
+        "id": "test-offering-id",
+        "paymentModel": "pay_now",
+        "price": {
+          "amount": 100,
+          "currency": {
+            "baseUnit": 100,
+            "isoCode": "USD",
+          },
+          "text": "$1.00",
+        },
+        "prices": [
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "USD",
+            },
+            "text": "$1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "EUR",
+            },
+            "text": "€1.00",
+          },
+          {
+            "amount": 100,
+            "currency": {
+              "baseUnit": 100,
+              "isoCode": "BRL",
+            },
+            "text": "R$1.00",
+          },
+        ],
+        "recurringDetails": {
+          "billingInterval": "day",
+          "intervalCount": 1,
+        },
+        "salesModel": "subscription",
+        "timePassDetails": null,
+      },
+    },
+  ],
 }
 `;


### PR DESCRIPTION
This PR formats properties including prices of `mainOffering` and `upsellOffering` offering pairs in `upsells` object returned in the `getExperience`. This unblocks clients, allowing them to use the formatted prices returned by the `supertab-browser` in their integrations rather than having to format prices of upsell offerings on their end.