### PR TITLE
fix: check against subscription id that can be a None string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,9 @@ export class Supertab {
           validTo: access.access.validTo
             ? new Date(access.access.validTo * 1000)
             : undefined,
-          isSubscription: !!access.access.subscriptionId,
+          isSubscription:
+            !!access.access.subscriptionId &&
+            access.access.subscriptionId !== "None",
         },
       };
     }


### PR DESCRIPTION
[Jira ticket](https://laterpay.atlassian.net/browse/CL-1845)

This PR is a temporary fix for checking if `subscription_id` is `None`:

![image](https://github.com/user-attachments/assets/67f97a99-2c14-4512-8f28-62ca2c53d2a6)

More context [here](https://supertab.slack.com/archives/C07TV0SUGSC/p1738329991624189)

Next steps: 
- Update `supertab-browser` version in `supertab-js` once this is merged