### PR TITLE
fix(CL-1869): default to redirect URI from experience config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export class Supertab {
     state?: object;
     redirectUri?: string;
   } = {}) {
+    const experiencesConfig = await this.#getClientExperiencesConfig();
     return authFlow({
       silently: !!silently,
       screenHint,
@@ -114,7 +115,7 @@ export class Supertab {
       authUrl: this.systemUrls.authUrl,
       tokenUrl: this.systemUrls.tokenUrl,
       redirectUri: `${this.systemUrls.ssoBaseUrl}/oauth2/auth-proxy?origin=${
-        redirectUri ?? window.location.origin
+        redirectUri ?? experiencesConfig.redirectUri
       }`,
       clientId: this.clientId,
     });


### PR DESCRIPTION
Ref: https://laterpay.atlassian.net/browse/CL-1869

## Summary

- This fixes a regression from the COW to `supertab-js` (which uses `supertab-browser` for OAuth)
- Default to the `redirectUri` from the experience config API response instead of using `window.location.origin`
- Our OAuth setup can only support subdomains (like www) if we use the `redirectUri` from the experience config, not the current page's origin

## Details

- See the related Slack discussion for more details: https://supertab.slack.com/archives/C044ZLL80E9/p1739370146174699