### PR TITLE
fix(CL-1869): Use full redirect URI from experiences config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,9 +114,9 @@ export class Supertab {
       state,
       authUrl: this.systemUrls.authUrl,
       tokenUrl: this.systemUrls.tokenUrl,
-      redirectUri: `${this.systemUrls.ssoBaseUrl}/oauth2/auth-proxy?origin=${
-        redirectUri ?? experiencesConfig.redirectUri
-      }`,
+      redirectUri: redirectUri
+        ? `${this.systemUrls.ssoBaseUrl}/oauth2/auth-proxy?origin=${redirectUri}`
+        : experiencesConfig.redirectUri,
       clientId: this.clientId,
     });
   }


### PR DESCRIPTION
Ref: https://laterpay.atlassian.net/browse/CL-1869

## Summary

- The first attempt to fix the issue (#175) resulted in a duplication of the base part of the redirect URI
- The `redirectUri` from the experiences config API response already contains the **full URL**
