### PR TITLE
fix: allow to pass metadata to the purchase function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -363,9 +363,13 @@ export class Supertab {
   async purchase({
     offeringId,
     preferredCurrencyCode = this.preferredCurrencyCode,
+    metadata = {},
   }: {
     offeringId: string;
     preferredCurrencyCode?: string;
+    metadata?: {
+      [key: string]: object;
+    } | null;
   }): Promise<{
     itemAdded: boolean;
     purchaseOutcome: PurchaseOutcome | null;
@@ -386,7 +390,7 @@ export class Supertab {
         offeringId,
         currency,
         purchaseOfferingRequest: {
-          metadata: {},
+          metadata,
         },
       });
 


### PR DESCRIPTION
### Jira Ticket
[CL-1870](https://laterpay.atlassian.net/browse/CL-1870)


Changes: 
- Allowed to pass metadata prop to the `purchase` function

[CL-1870]: https://laterpay.atlassian.net/browse/CL-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ