### PR TITLE
fix: authorize cross-origin window

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -28,8 +28,17 @@ export const handleChildWindow = async <T>({
     }
   };
 
-  const isUrlOpened =
-    openedWindow.location && openedWindow.location.href === url.toString();
+  let isUrlOpened = false;
+
+  // We can't directly access openedWindow.location.href once the page navigates to a cross-origin.
+  try {
+    isUrlOpened =
+      openedWindow.location && openedWindow.location.href === url.toString();
+  } catch (e) {
+    // Cross-origin — can't access href
+    console.log("Cross-origin access error while checking window location:", e);
+    isUrlOpened = false;
+  }
 
   if (!isUrlOpened) {
     setWindowLocation();


### PR DESCRIPTION
## Jira ticket

[CL-1918](https://laterpay.atlassian.net/browse/CL-1918)

## Context

**Bug:** The bug was caused by a SecurityError thrown when attempting to access openedWindow.location.href after the child window navigated to a cross-origin URL.

**Fix:** The fix wraps the access in a try/catch to safely detect when the URL is no longer accessible due to same-origin policy restrictions. 

- I was able to reproduce the bug for other browsers (not just for Safari)
- the fix was tested via `yarn link`

## Bug 

<img width="1069" alt="Screenshot 2025-04-07 at 11 19 31" src="https://github.com/user-attachments/assets/9c15967d-8f58-4dfa-8735-de607acd854a" />

https://github.com/user-attachments/assets/2b8fd126-5d69-4c18-aa57-7909a6c40206

## Fix

https://github.com/user-attachments/assets/f6c13ab2-79a1-4608-81d2-e18027fc14d6



[CL-1918]: https://laterpay.atlassian.net/browse/CL-1918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ