### PR TITLE
feat: add highlighted upsell offering ids to `UiConfig`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -47,10 +47,12 @@ export type UiConfig = {
     offeringIds: (string | null)[];
     highlightedOfferingId: string;
     upsellOfferingIds: (string | null)[];
+    highlightedUpsellOfferingIds: (string | null)[];
   } | null;
   moreOptionsScreen: {
     offeringIds: (string | null)[];
     highlightedOfferingId: string;
     upsellOfferingIds: (string | null)[];
+    highlightedUpsellOfferingIds: (string | null)[];
   } | null;
 };


### PR DESCRIPTION
This PR adds `highlightedUpsellOfferingIds` to `UiConfig` type for both `mainScreen` and `moreOptionsScreen`. This is to support the development of a new feature to allow highlighting upsells in the business portal.

_Note: To fully deprecate this package and stop relying on it, we should consider moving these types somewhere else. Currently, Business Portal and Design System use them. To be addressed separately, will add to agenda for next eng sync._